### PR TITLE
Improve blocks parser: support single line blocks and more.

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,6 @@ fn bar() {
 
 - Deleted blocks are currently ignored.
 - Files with unsupported grammar are ignored.
-- Multiple blocks cannot be declared on a single line: `<block><block>will not work</block></block>`.
 
 ## Contributing
 

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -68,24 +68,6 @@ impl Block {
     }
 }
 
-pub(crate) struct BlockBuilder {
-    pub(crate) starts_at: usize,
-    attributes: HashMap<String, String>,
-}
-
-impl BlockBuilder {
-    pub(crate) fn new(starts_at: usize, attributes: HashMap<String, String>) -> Self {
-        Self {
-            starts_at,
-            attributes,
-        }
-    }
-
-    pub(crate) fn build(self, ends_at: usize, content: String) -> Block {
-        Block::new(self.starts_at, ends_at, self.attributes, content)
-    }
-}
-
 pub(crate) async fn parse_blocks(
     modified_ranges_by_file: &HashMap<String, Vec<(usize, usize)>>,
     file_reader: &impl FileReader,

--- a/src/parsers/bash.rs
+++ b/src/parsers/bash.rs
@@ -32,6 +32,7 @@ fn comments_parser() -> anyhow::Result<impl CommentsParser> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parsers::Comment;
 
     #[test]
     fn parses_comments_correctly() -> anyhow::Result<()> {
@@ -53,12 +54,42 @@ VALUE=42  # Comment after code
         assert_eq!(
             blocks,
             vec![
-                (2, "This is a single line comment".to_string()),
-                (3, "This is an inline comment".to_string()),
-                (5, "This is a multi-line".to_string()),
-                (6, "comment that spans".to_string()),
-                (7, "several lines".to_string()),
-                (9, "Comment after code".to_string()),
+                Comment {
+                    source_line_number: 2,
+                    source_start_position: 12,
+                    source_end_position: 43,
+                    comment_text: "This is a single line comment".to_string()
+                },
+                Comment {
+                    source_line_number: 3,
+                    source_start_position: 58,
+                    source_end_position: 85,
+                    comment_text: "This is an inline comment".to_string()
+                },
+                Comment {
+                    source_line_number: 5,
+                    source_start_position: 87,
+                    source_end_position: 109,
+                    comment_text: "This is a multi-line".to_string()
+                },
+                Comment {
+                    source_line_number: 6,
+                    source_start_position: 110,
+                    source_end_position: 130,
+                    comment_text: "comment that spans".to_string()
+                },
+                Comment {
+                    source_line_number: 7,
+                    source_start_position: 131,
+                    source_end_position: 146,
+                    comment_text: "several lines".to_string()
+                },
+                Comment {
+                    source_line_number: 9,
+                    source_start_position: 158,
+                    source_end_position: 178,
+                    comment_text: "Comment after code".to_string()
+                },
             ]
         );
 

--- a/src/parsers/c.rs
+++ b/src/parsers/c.rs
@@ -45,6 +45,7 @@ fn comments_parser() -> anyhow::Result<impl CommentsParser> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parsers::Comment;
 
     #[test]
     fn parses_c_comments_correctly() -> anyhow::Result<()> {
@@ -76,16 +77,32 @@ mod tests {
         assert_eq!(
             blocks,
             vec![
-                (2, "This is a single-line comment in C.".to_string()),
-                (
-                    5,
-                    "\nThis is a multi-line comment.\nIt spans multiple lines in C.\n".to_string()
-                ),
-                (11, "Prints a message to the console.".to_string()),
-                (
-                    13,
-                    "Another comment\nsplit into\nmultiple lines.\n".to_string()
-                )
+                Comment {
+                    source_line_number: 2,
+                    source_start_position: 13,
+                    source_end_position: 51,
+                    comment_text: "This is a single-line comment in C.".to_string()
+                },
+                Comment {
+                    source_line_number: 5,
+                    source_start_position: 96,
+                    source_end_position: 204,
+                    comment_text:
+                        "\nThis is a multi-line comment.\nIt spans multiple lines in C.\n"
+                            .to_string()
+                },
+                Comment {
+                    source_line_number: 11,
+                    source_start_position: 270,
+                    source_end_position: 305,
+                    comment_text: "Prints a message to the console.".to_string()
+                },
+                Comment {
+                    source_line_number: 13,
+                    source_start_position: 323,
+                    source_end_position: 426,
+                    comment_text: "Another comment\nsplit into\nmultiple lines.\n".to_string()
+                },
             ]
         );
 

--- a/src/parsers/c_sharp.rs
+++ b/src/parsers/c_sharp.rs
@@ -52,6 +52,7 @@ fn comments_parser() -> anyhow::Result<impl CommentsParser> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parsers::Comment;
 
     #[test]
     fn parses_c_sharp_comments_correctly() -> anyhow::Result<()> {
@@ -84,13 +85,48 @@ namespace HelloWorld
         assert_eq!(
             blocks,
             vec![
-                (2, "Single line comment".to_string()),
-                (7, "Multi-line\ncomment example.\n".to_string()),
-                (12, "<summary>".to_string()), // Note: Current parser logic treats /// like //
-                (13, "XML Doc comment.".to_string()),
-                (14, "</summary>".to_string()),
-                (17, "Another single line".to_string()),
-                (18, "Simple block".to_string())
+                Comment {
+                    source_line_number: 2,
+                    source_start_position: 1,
+                    source_end_position: 23,
+                    comment_text: "Single line comment".to_string()
+                },
+                Comment {
+                    source_line_number: 7,
+                    source_start_position: 66,
+                    source_end_position: 111,
+                    comment_text: "Multi-line\ncomment example.\n".to_string()
+                },
+                Comment {
+                    source_line_number: 12,
+                    source_start_position: 144,
+                    source_end_position: 157,
+                    comment_text: "<summary>".to_string()
+                },
+                Comment {
+                    source_line_number: 13,
+                    source_start_position: 166,
+                    source_end_position: 186,
+                    comment_text: "XML Doc comment.".to_string()
+                },
+                Comment {
+                    source_line_number: 14,
+                    source_start_position: 195,
+                    source_end_position: 209,
+                    comment_text: "</summary>".to_string()
+                },
+                Comment {
+                    source_line_number: 17,
+                    source_start_position: 307,
+                    source_end_position: 329,
+                    comment_text: "Another single line".to_string()
+                },
+                Comment {
+                    source_line_number: 18,
+                    source_start_position: 342,
+                    source_end_position: 360,
+                    comment_text: "Simple block".to_string()
+                }
             ]
         );
 

--- a/src/parsers/cpp.rs
+++ b/src/parsers/cpp.rs
@@ -45,6 +45,7 @@ fn comments_parser() -> anyhow::Result<impl CommentsParser> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parsers::Comment;
 
     #[test]
     fn parses_cpp_comments_correctly() -> anyhow::Result<()> {
@@ -76,13 +77,31 @@ mod tests {
         assert_eq!(
             blocks,
             vec![
-                (2, "This is a single-line comment in C++.".to_string()),
-                (
-                    5,
-                    "\nThis is a multi-line comment.\nIt spans multiple lines.\n".to_string()
-                ),
-                (11, "Prints a message to the console.".to_string()),
-                (13, "This is another\nmulti-line\ncomment.\n".to_string())
+                Comment {
+                    source_line_number: 2,
+                    source_start_position: 13,
+                    source_end_position: 53,
+                    comment_text: "This is a single-line comment in C++.".to_string()
+                },
+                Comment {
+                    source_line_number: 5,
+                    source_start_position: 99,
+                    source_end_position: 202,
+                    comment_text: "\nThis is a multi-line comment.\nIt spans multiple lines.\n"
+                        .to_string()
+                },
+                Comment {
+                    source_line_number: 11,
+                    source_start_position: 286,
+                    source_end_position: 321,
+                    comment_text: "Prints a message to the console.".to_string()
+                },
+                Comment {
+                    source_line_number: 13,
+                    source_start_position: 339,
+                    source_end_position: 435,
+                    comment_text: "This is another\nmulti-line\ncomment.\n".to_string()
+                },
             ]
         );
 

--- a/src/parsers/css.rs
+++ b/src/parsers/css.rs
@@ -41,6 +41,7 @@ fn comments_parser() -> anyhow::Result<impl CommentsParser> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parsers::Comment;
 
     #[test]
     fn parses_css_comments_correctly() -> anyhow::Result<()> {
@@ -70,15 +71,26 @@ mod tests {
         assert_eq!(
             blocks,
             vec![
-                (6, "This is a CSS comment".to_string()),
-                (
-                    8,
-                    "This is a multi-line\nCSS comment that spans\nmultiple lines\n".to_string()
-                ),
-                (
-                    15,
-                    "Another multi-line\nCSS comment with\ndifferent formatting".to_string()
-                )
+                Comment {
+                    source_line_number: 6,
+                    source_start_position: 81,
+                    source_end_position: 108,
+                    comment_text: "This is a CSS comment".to_string()
+                },
+                Comment {
+                    source_line_number: 8,
+                    source_start_position: 147,
+                    source_end_position: 266,
+                    comment_text: "This is a multi-line\nCSS comment that spans\nmultiple lines\n"
+                        .to_string()
+                },
+                Comment {
+                    source_line_number: 15,
+                    source_start_position: 339,
+                    source_end_position: 431,
+                    comment_text: "Another multi-line\nCSS comment with\ndifferent formatting"
+                        .to_string()
+                },
             ]
         );
 

--- a/src/parsers/go.rs
+++ b/src/parsers/go.rs
@@ -45,6 +45,7 @@ fn comments_parser() -> anyhow::Result<impl CommentsParser> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parsers::Comment;
 
     #[test]
     fn parses_go_comments_correctly() -> anyhow::Result<()> {
@@ -72,13 +73,31 @@ func main() {
         assert_eq!(
             blocks,
             vec![
-                (2, "This is a single line comment in Go".to_string()),
-                (
-                    5,
-                    "\nThis is a multi-line comment\nspanning several lines\n".to_string()
-                ),
-                (13, "Inline comment".to_string()),
-                (14, "Another single line comment".to_string()),
+                Comment {
+                    source_line_number: 2,
+                    source_start_position: 1,
+                    source_end_position: 39,
+                    comment_text: "This is a single line comment in Go".to_string()
+                },
+                Comment {
+                    source_line_number: 5,
+                    source_start_position: 54,
+                    source_end_position: 111,
+                    comment_text: "\nThis is a multi-line comment\nspanning several lines\n"
+                        .to_string()
+                },
+                Comment {
+                    source_line_number: 13,
+                    source_start_position: 174,
+                    source_end_position: 191,
+                    comment_text: "Inline comment".to_string()
+                },
+                Comment {
+                    source_line_number: 14,
+                    source_start_position: 196,
+                    source_end_position: 226,
+                    comment_text: "Another single line comment".to_string()
+                },
             ]
         );
 

--- a/src/parsers/html.rs
+++ b/src/parsers/html.rs
@@ -36,6 +36,7 @@ fn comments_parser() -> anyhow::Result<impl CommentsParser> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parsers::Comment;
 
     #[test]
     fn parses_html_comments_correctly() -> anyhow::Result<()> {
@@ -59,10 +60,30 @@ mod tests {
         assert_eq!(
             blocks,
             vec![
-                (2, "Simple comment".to_string()),
-                (4, "Another comment".to_string()),
-                (6, "\nMulti-line comment\nwith multiple lines\n".to_string()),
-                (11, "Final comment".to_string()),
+                Comment {
+                    source_line_number: 2,
+                    source_start_position: 28,
+                    source_end_position: 51,
+                    comment_text: "Simple comment".to_string()
+                },
+                Comment {
+                    source_line_number: 4,
+                    source_start_position: 86,
+                    source_end_position: 110,
+                    comment_text: "Another comment".to_string()
+                },
+                Comment {
+                    source_line_number: 6,
+                    source_start_position: 160,
+                    source_end_position: 255,
+                    comment_text: "\nMulti-line comment\nwith multiple lines\n".to_string()
+                },
+                Comment {
+                    source_line_number: 11,
+                    source_start_position: 287,
+                    source_end_position: 309,
+                    comment_text: "Final comment".to_string()
+                },
             ]
         );
 

--- a/src/parsers/java.rs
+++ b/src/parsers/java.rs
@@ -47,6 +47,7 @@ fn comments_parser() -> anyhow::Result<impl CommentsParser> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parsers::Comment;
 
     #[test]
     fn parses_comments_correctly() -> anyhow::Result<()> {
@@ -88,13 +89,48 @@ mod tests {
         assert_eq!(
             blocks,
             vec![
-                (2, "\nThis is a simple Java program demonstrating different types of comments.\n\n@version 1.0\n".to_string()),
-                (10, "This is a single-line comment.".to_string()),
-                (11, "Prints a message to the console.".to_string()),
-                (13, "\nThis is a multi-line comment.\nIt can span multiple lines.\n".to_string()),
-                (17, "Assigning a value to the variable ".to_string()),
-                (19, "This is a single-line doc-comment. ".to_string()),
-                (23, "\nPrints a sample message to the console.\n".to_string())
+                Comment {
+                    source_line_number: 2,
+                    source_start_position: 9,
+                    source_end_position: 144,
+                    comment_text: "\nThis is a simple Java program demonstrating different types of comments.\n\n@version 1.0\n".to_string()
+                },
+                Comment {
+                    source_line_number: 10,
+                    source_start_position: 261,
+                    source_end_position: 294,
+                    comment_text: "This is a single-line comment.".to_string()
+                },
+                Comment {
+                    source_line_number: 11,
+                    source_start_position: 348,
+                    source_end_position: 383,
+                    comment_text: "Prints a message to the console.".to_string()
+                },
+                Comment {
+                    source_line_number: 13,
+                    source_start_position: 409,
+                    source_end_position: 527,
+                    comment_text: "\nThis is a multi-line comment.\nIt can span multiple lines.\n".to_string()
+                },
+                Comment {
+                    source_line_number: 17,
+                    source_start_position: 561,
+                    source_end_position: 600,
+                    comment_text: "Assigning a value to the variable ".to_string()
+                },
+                Comment {
+                    source_line_number: 19,
+                    source_start_position: 626,
+                    source_end_position: 667,
+                    comment_text: "This is a single-line doc-comment. ".to_string()
+                },
+                Comment {
+                    source_line_number: 23,
+                    source_start_position: 735,
+                    source_end_position: 809,
+                    comment_text: "\nPrints a sample message to the console.\n".to_string()
+                }
             ]
         );
 

--- a/src/parsers/javascript.rs
+++ b/src/parsers/javascript.rs
@@ -45,6 +45,7 @@ fn comments_parser() -> anyhow::Result<impl CommentsParser> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parsers::Comment;
 
     #[test]
     fn parses_comments_correctly() -> anyhow::Result<()> {
@@ -73,11 +74,38 @@ mod tests {
         assert_eq!(
             blocks,
             vec![
-                (2, "\nThis is a JavaScript function demonstration with comments.\n\n@author Author name\n".to_string()),
-                (8, "This is a single-line comment in JavaScript.".to_string()),
-                (9, "Inline comment after a statement.".to_string()),
-                (11, "\nThis is a multi-line comment.\nIt also spans multiple lines.\n".to_string()),
-                (15, "Inline multi-line comment".to_string())
+                Comment {
+                    source_line_number: 2,
+                    source_start_position: 13,
+                    source_end_position: 156,
+                    comment_text: "\nThis is a JavaScript function demonstration with comments.\n\n@author Author name\n".to_string()
+                },
+                Comment {
+                    source_line_number: 8,
+                    source_start_position: 206,
+                    source_end_position: 253,
+                    comment_text: "This is a single-line comment in JavaScript."
+                        .to_string()
+                },
+                Comment {
+                    source_line_number: 9,
+                    source_start_position: 305,
+                    source_end_position: 341,
+                    comment_text: "Inline comment after a statement.".to_string()
+                },
+                Comment {
+                    source_line_number: 11,
+                    source_start_position: 359,
+                    source_end_position: 479,
+                    comment_text: "\nThis is a multi-line comment.\nIt also spans multiple lines.\n"
+                        .to_string()
+                },
+                Comment {
+                    source_line_number: 15,
+                    source_start_position: 513,
+                    source_end_position: 544,
+                    comment_text: "Inline multi-line comment".to_string()
+                },
             ]
         );
 

--- a/src/parsers/kotlin.rs
+++ b/src/parsers/kotlin.rs
@@ -48,6 +48,7 @@ fn comments_parser() -> anyhow::Result<impl CommentsParser> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parsers::Comment;
 
     #[test]
     fn parses_kotlin_comments_correctly() -> anyhow::Result<()> {
@@ -78,17 +79,32 @@ mod tests {
         assert_eq!(
             blocks,
             vec![
-                (2, "This is a single-line comment in Kotlin".to_string()),
-                (
-                    5,
-                    "\nThis is a multi-line comment.\nIt spans multiple lines in Kotlin.\n"
-                        .to_string()
-                ),
-                (10, "Prints a message".to_string()),
-                (
-                    12,
-                    "Another comment\nsplit into\nmultiple lines\n".to_string()
-                )
+                Comment {
+                    source_line_number: 2,
+                    source_start_position: 13,
+                    source_end_position: 55,
+                    comment_text: "This is a single-line comment in Kotlin".to_string()
+                },
+                Comment {
+                    source_line_number: 5,
+                    source_start_position: 110,
+                    source_end_position: 223,
+                    comment_text:
+                        "\nThis is a multi-line comment.\nIt spans multiple lines in Kotlin.\n"
+                            .to_string()
+                },
+                Comment {
+                    source_line_number: 10,
+                    source_start_position: 279,
+                    source_end_position: 298,
+                    comment_text: "Prints a message".to_string()
+                },
+                Comment {
+                    source_line_number: 12,
+                    source_start_position: 332,
+                    source_end_position: 434,
+                    comment_text: "Another comment\nsplit into\nmultiple lines\n".to_string()
+                },
             ]
         );
 

--- a/src/parsers/markdown.rs
+++ b/src/parsers/markdown.rs
@@ -47,6 +47,7 @@ fn comments_parser() -> anyhow::Result<impl CommentsParser> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parsers::Comment;
 
     #[test]
     fn parses_markdown_comments_correctly() -> anyhow::Result<()> {
@@ -70,9 +71,24 @@ in it)"#,
         assert_eq!(
             blocks,
             vec![
-                (5, "This is a markdown comment".to_string()),
-                (6, "Another markdown comment".to_string()),
-                (10, "Third comment with\nmultiple lines\nin it".to_string()),
+                Comment {
+                    source_line_number: 5,
+                    source_start_position: 31,
+                    source_end_position: 68,
+                    comment_text: "This is a markdown comment".to_string()
+                },
+                Comment {
+                    source_line_number: 6,
+                    source_start_position: 68,
+                    source_end_position: 104,
+                    comment_text: "Another markdown comment".to_string()
+                },
+                Comment {
+                    source_line_number: 10,
+                    source_start_position: 121,
+                    source_end_position: 170,
+                    comment_text: "Third comment with\nmultiple lines\nin it".to_string()
+                },
             ]
         );
 

--- a/src/parsers/php.rs
+++ b/src/parsers/php.rs
@@ -47,6 +47,7 @@ fn comments_parser() -> anyhow::Result<impl CommentsParser> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parsers::Comment;
 
     #[test]
     fn parses_php_comments_correctly() -> anyhow::Result<()> {
@@ -80,18 +81,38 @@ mod tests {
         assert_eq!(
             blocks,
             vec![
-                (2, "This is a single-line comment in PHP".to_string()),
-                (
-                    4,
-                    "\nThis is a multi-line comment.\nIt spans multiple lines in PHP.\n"
-                        .to_string()
-                ),
-                (10, "Prints a message to the console.".to_string()),
-                (
-                    12,
-                    "Another comment\nsplit into\nmultiple lines.\n".to_string()
-                ),
-                (20, "inlined comment".to_string())
+                Comment {
+                    source_line_number: 2,
+                    source_start_position: 18,
+                    source_end_position: 57,
+                    comment_text: "This is a single-line comment in PHP".to_string()
+                },
+                Comment {
+                    source_line_number: 4,
+                    source_start_position: 75,
+                    source_end_position: 185,
+                    comment_text:
+                        "\nThis is a multi-line comment.\nIt spans multiple lines in PHP.\n"
+                            .to_string()
+                },
+                Comment {
+                    source_line_number: 10,
+                    source_start_position: 257,
+                    source_end_position: 291,
+                    comment_text: "Prints a message to the console.".to_string()
+                },
+                Comment {
+                    source_line_number: 12,
+                    source_start_position: 313,
+                    source_end_position: 416,
+                    comment_text: "Another comment\nsplit into\nmultiple lines.\n".to_string()
+                },
+                Comment {
+                    source_line_number: 20,
+                    source_start_position: 523,
+                    source_end_position: 541,
+                    comment_text: "inlined comment".to_string()
+                },
             ]
         );
 

--- a/src/parsers/python.rs
+++ b/src/parsers/python.rs
@@ -24,6 +24,7 @@ fn comments_parser() -> anyhow::Result<impl CommentsParser> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parsers::Comment;
 
     #[test]
     fn parses_comments_correctly() -> anyhow::Result<()> {
@@ -46,12 +47,42 @@ value = 42  # Comment after code
         assert_eq!(
             blocks,
             vec![
-                (3, "This is a single line comment".to_string()),
-                (4, "This is an inline comment".to_string()),
-                (6, "This is a multi-line".to_string()),
-                (7, "comment that spans".to_string()),
-                (8, "several lines".to_string()),
-                (10, "Comment after code".to_string()),
+                Comment {
+                    source_line_number: 3,
+                    source_start_position: 17,
+                    source_end_position: 48,
+                    comment_text: "This is a single line comment".to_string()
+                },
+                Comment {
+                    source_line_number: 4,
+                    source_start_position: 69,
+                    source_end_position: 96,
+                    comment_text: "This is an inline comment".to_string()
+                },
+                Comment {
+                    source_line_number: 6,
+                    source_start_position: 98,
+                    source_end_position: 120,
+                    comment_text: "This is a multi-line".to_string()
+                },
+                Comment {
+                    source_line_number: 7,
+                    source_start_position: 121,
+                    source_end_position: 141,
+                    comment_text: "comment that spans".to_string()
+                },
+                Comment {
+                    source_line_number: 8,
+                    source_start_position: 142,
+                    source_end_position: 157,
+                    comment_text: "several lines".to_string()
+                },
+                Comment {
+                    source_line_number: 10,
+                    source_start_position: 171,
+                    source_end_position: 191,
+                    comment_text: "Comment after code".to_string()
+                },
             ]
         );
 

--- a/src/parsers/ruby.rs
+++ b/src/parsers/ruby.rs
@@ -24,6 +24,7 @@ fn comments_parser() -> anyhow::Result<impl CommentsParser> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parsers::Comment;
 
     #[test]
     fn parses_comments_correctly() -> anyhow::Result<()> {
@@ -46,12 +47,42 @@ value = 42  # Comment after code
         assert_eq!(
             blocks,
             vec![
-                (3, "This is a single line comment".to_string()),
-                (4, "This is an inline comment".to_string()),
-                (6, "This is a multi-line".to_string()),
-                (7, "comment that spans".to_string()),
-                (8, "several lines".to_string()),
-                (10, "Comment after code".to_string()),
+                Comment {
+                    source_line_number: 3,
+                    source_start_position: 30,
+                    source_end_position: 61,
+                    comment_text: "This is a single line comment".to_string()
+                },
+                Comment {
+                    source_line_number: 4,
+                    source_start_position: 113,
+                    source_end_position: 140,
+                    comment_text: "This is an inline comment".to_string()
+                },
+                Comment {
+                    source_line_number: 6,
+                    source_start_position: 142,
+                    source_end_position: 164,
+                    comment_text: "This is a multi-line".to_string()
+                },
+                Comment {
+                    source_line_number: 7,
+                    source_start_position: 165,
+                    source_end_position: 185,
+                    comment_text: "comment that spans".to_string()
+                },
+                Comment {
+                    source_line_number: 8,
+                    source_start_position: 186,
+                    source_end_position: 201,
+                    comment_text: "several lines".to_string()
+                },
+                Comment {
+                    source_line_number: 10,
+                    source_start_position: 215,
+                    source_end_position: 235,
+                    comment_text: "Comment after code".to_string()
+                }
             ]
         );
 

--- a/src/parsers/rust.rs
+++ b/src/parsers/rust.rs
@@ -57,6 +57,7 @@ fn comments_parser() -> anyhow::Result<impl CommentsParser> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parsers::Comment;
 
     #[test]
     fn parses_comments_correctly() -> anyhow::Result<()> {
@@ -94,23 +95,55 @@ mod tests {
         assert_eq!(
             blocks,
             vec![
-                (
-                    2,
-                    "This is a crate-level documentation comment.".to_string()
-                ),
-                (
-                    3,
-                    "It provides an overview of the module or library.".to_string()
-                ),
-                (5, "This function adds two numbers.".to_string()),
-                (6, "".to_string()),
-                (7, "Returns the sum of `a` and `b`.".to_string()),
-                (13, "This is a single-line comment.".to_string()),
-                (
-                    16,
-                    "\nThis is a block comment.\nIt can span multiple lines.\n".to_string()
-                ),
-                (24, "Using the add function.".to_string()),
+                Comment {
+                    source_line_number: 2,
+                    source_start_position: 9,
+                    source_end_position: 58,
+                    comment_text: "This is a crate-level documentation comment.".to_string()
+                },
+                Comment {
+                    source_line_number: 3,
+                    source_start_position: 66,
+                    source_end_position: 120,
+                    comment_text: "It provides an overview of the module or library.".to_string()
+                },
+                Comment {
+                    source_line_number: 5,
+                    source_start_position: 137,
+                    source_end_position: 173,
+                    comment_text: "This function adds two numbers.".to_string()
+                },
+                Comment {
+                    source_line_number: 6,
+                    source_start_position: 181,
+                    source_end_position: 185,
+                    comment_text: "".to_string()
+                },
+                Comment {
+                    source_line_number: 7,
+                    source_start_position: 193,
+                    source_end_position: 229,
+                    comment_text: "Returns the sum of `a` and `b`.".to_string()
+                },
+                Comment {
+                    source_line_number: 13,
+                    source_start_position: 338,
+                    source_end_position: 371,
+                    comment_text: "This is a single-line comment.".to_string()
+                },
+                Comment {
+                    source_line_number: 16,
+                    source_start_position: 431,
+                    source_end_position: 532,
+                    comment_text: "\nThis is a block comment.\nIt can span multiple lines.\n"
+                        .to_string()
+                },
+                Comment {
+                    source_line_number: 24,
+                    source_start_position: 662,
+                    source_end_position: 688,
+                    comment_text: "Using the add function.".to_string()
+                }
             ]
         );
 

--- a/src/parsers/sql.rs
+++ b/src/parsers/sql.rs
@@ -41,6 +41,7 @@ fn comments_parser() -> anyhow::Result<impl CommentsParser> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parsers::Comment;
 
     #[test]
     fn parses_comments_correctly() -> anyhow::Result<()> {
@@ -67,16 +68,49 @@ SELECT COUNT(*) FROM orders; /* Inline block comment */
         assert_eq!(
             blocks,
             vec![
-                (3, "This is a single line comment".to_string()),
-                (4, "This is an inline comment".to_string()),
-                (6, "This is a multi-line".to_string()),
-                (7, "comment that spans".to_string()),
-                (8, "several lines".to_string()),
-                (
-                    10,
-                    "This is a block comment\nthat spans multiple lines\n".to_string()
-                ),
-                (14, "Inline block comment".to_string()),
+                Comment {
+                    source_line_number: 3,
+                    source_start_position: 21,
+                    source_end_position: 53,
+                    comment_text: "This is a single line comment".to_string()
+                },
+                Comment {
+                    source_line_number: 4,
+                    source_start_position: 69,
+                    source_end_position: 97,
+                    comment_text: "This is an inline comment".to_string()
+                },
+                Comment {
+                    source_line_number: 6,
+                    source_start_position: 99,
+                    source_end_position: 122,
+                    comment_text: "This is a multi-line".to_string()
+                },
+                Comment {
+                    source_line_number: 7,
+                    source_start_position: 123,
+                    source_end_position: 144,
+                    comment_text: "comment that spans".to_string()
+                },
+                Comment {
+                    source_line_number: 8,
+                    source_start_position: 145,
+                    source_end_position: 161,
+                    comment_text: "several lines".to_string()
+                },
+                Comment {
+                    source_line_number: 10,
+                    source_start_position: 163,
+                    source_end_position: 219,
+                    comment_text: "This is a block comment\nthat spans multiple lines\n"
+                        .to_string()
+                },
+                Comment {
+                    source_line_number: 14,
+                    source_start_position: 250,
+                    source_end_position: 276,
+                    comment_text: "Inline block comment".to_string()
+                }
             ]
         );
 

--- a/src/parsers/swift.rs
+++ b/src/parsers/swift.rs
@@ -48,6 +48,7 @@ fn comments_parser() -> anyhow::Result<impl CommentsParser> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parsers::Comment;
 
     #[test]
     fn parses_swift_comments_correctly() -> anyhow::Result<()> {
@@ -79,17 +80,32 @@ mod tests {
         assert_eq!(
             blocks,
             vec![
-                (2, "This is a single-line comment in Swift.".to_string()),
-                (
-                    5,
-                    "\nThis is a multi-line comment.\nIt spans multiple lines in Swift.\n"
-                        .to_string()
-                ),
-                (11, "Prints a message to the console.".to_string()),
-                (
-                    13,
-                    "Another comment\nsplit into\nmultiple lines.\n".to_string()
-                )
+                Comment {
+                    source_line_number: 2,
+                    source_start_position: 13,
+                    source_end_position: 55,
+                    comment_text: "This is a single-line comment in Swift.".to_string()
+                },
+                Comment {
+                    source_line_number: 5,
+                    source_start_position: 103,
+                    source_end_position: 215,
+                    comment_text:
+                        "\nThis is a multi-line comment.\nIt spans multiple lines in Swift.\n"
+                            .to_string()
+                },
+                Comment {
+                    source_line_number: 11,
+                    source_start_position: 286,
+                    source_end_position: 321,
+                    comment_text: "Prints a message to the console.".to_string()
+                },
+                Comment {
+                    source_line_number: 13,
+                    source_start_position: 343,
+                    source_end_position: 446,
+                    comment_text: "Another comment\nsplit into\nmultiple lines.\n".to_string()
+                }
             ]
         );
 

--- a/src/parsers/toml.rs
+++ b/src/parsers/toml.rs
@@ -24,6 +24,7 @@ fn comments_parser() -> anyhow::Result<impl CommentsParser> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parsers::Comment;
 
     #[test]
     fn parses_toml_comments_correctly() -> anyhow::Result<()> {
@@ -44,12 +45,42 @@ dob = 1979-05-27T07:32:00-08:00 # Date of birth with comment
         assert_eq!(
             blocks,
             vec![
-                (2, "This is a TOML file".to_string()),
-                (3, "Inline comment".to_string()),
-                (5, "Owner's details".to_string()),
-                (6, "Another inline comment".to_string()),
-                (7, "Date of birth with comment".to_string()),
-                (8, "End of file".to_string()),
+                Comment {
+                    source_line_number: 2,
+                    source_start_position: 1,
+                    source_end_position: 22,
+                    comment_text: "This is a TOML file".to_string()
+                },
+                Comment {
+                    source_line_number: 3,
+                    source_start_position: 46,
+                    source_end_position: 62,
+                    comment_text: "Inline comment".to_string()
+                },
+                Comment {
+                    source_line_number: 5,
+                    source_start_position: 71,
+                    source_end_position: 88,
+                    comment_text: "Owner's details".to_string()
+                },
+                Comment {
+                    source_line_number: 6,
+                    source_start_position: 117,
+                    source_end_position: 141,
+                    comment_text: "Another inline comment".to_string()
+                },
+                Comment {
+                    source_line_number: 7,
+                    source_start_position: 174,
+                    source_end_position: 202,
+                    comment_text: "Date of birth with comment".to_string()
+                },
+                Comment {
+                    source_line_number: 8,
+                    source_start_position: 203,
+                    source_end_position: 216,
+                    comment_text: "End of file".to_string()
+                }
             ]
         );
 

--- a/src/parsers/tsx.rs
+++ b/src/parsers/tsx.rs
@@ -45,6 +45,7 @@ fn comments_parser() -> anyhow::Result<impl CommentsParser> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parsers::Comment;
 
     #[test]
     fn parses_tsx_comments_correctly() -> anyhow::Result<()> {
@@ -86,20 +87,52 @@ mod tests {
         assert_eq!(
             blocks,
             vec![
-                (
-                    2,
-                    "\nThis is a TSX component with comments.\n\n@component TSXExample\n"
-                        .to_string()
-                ),
-                (8, "This is a single-line comment in TSX.".to_string()),
-                (
-                    11,
-                    "\nThis is a multi-line comment\nused in a functional component.\n".to_string()
-                ),
-                (16, "Inline multi-line comment".to_string()),
-                (19, "Render the component".to_string()),
-                (22, "JSX single-line comment".to_string()),
-                (24, "JSX multi-line\ncomment".to_string()),
+                Comment {
+                    source_line_number: 2,
+                    source_start_position: 17,
+                    source_end_position: 158,
+                    comment_text:
+                        "\nThis is a TSX component with comments.\n\n@component TSXExample\n"
+                            .to_string()
+                },
+                Comment {
+                    source_line_number: 8,
+                    source_start_position: 222,
+                    source_end_position: 262,
+                    comment_text: "This is a single-line comment in TSX.".to_string()
+                },
+                Comment {
+                    source_line_number: 11,
+                    source_start_position: 343,
+                    source_end_position: 476,
+                    comment_text:
+                        "\nThis is a multi-line comment\nused in a functional component.\n"
+                            .to_string()
+                },
+                Comment {
+                    source_line_number: 16,
+                    source_start_position: 568,
+                    source_end_position: 599,
+                    comment_text: "Inline multi-line comment".to_string()
+                },
+                Comment {
+                    source_line_number: 19,
+                    source_start_position: 644,
+                    source_end_position: 667,
+                    comment_text: "Render the component".to_string()
+                },
+                Comment {
+                    source_line_number: 22,
+                    source_start_position: 756,
+                    source_end_position: 785,
+                    comment_text: "JSX single-line comment".to_string()
+                },
+                Comment {
+                    source_line_number: 24,
+                    source_start_position: 874,
+                    source_end_position: 931,
+                    comment_text: "JSX multi-line\ncomment".to_string()
+                }
             ]
         );
 

--- a/src/parsers/typescript.rs
+++ b/src/parsers/typescript.rs
@@ -45,6 +45,7 @@ fn comments_parser() -> anyhow::Result<impl CommentsParser> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parsers::Comment;
 
     #[test]
     fn parses_typescript_comments_correctly() -> anyhow::Result<()> {
@@ -80,23 +81,46 @@ mod tests {
         assert_eq!(
             blocks,
             vec![
-                (
-                    2,
-                    "\nThis is a TypeScript class example with comments.\n\n@class Example\n"
-                        .to_string()
-                ),
-                (
-                    8,
-                    "This is a single-line comment in TypeScript.".to_string()
-                ),
-                (
-                    11,
-                    "\nThis is a multi-line comment\nthat spans across several lines.\n"
-                        .to_string()
-                ),
-                (16, "Inline multi-line comment".to_string()),
-                (19, "Method to get the value".to_string()),
-                (21, "Inline comment next to a return statement".to_string())
+                Comment {
+                    source_line_number: 2,
+                    source_start_position: 13,
+                    source_end_position: 142,
+                    comment_text:
+                        "\nThis is a TypeScript class example with comments.\n\n@class Example\n"
+                            .to_string()
+                },
+                Comment {
+                    source_line_number: 8,
+                    source_start_position: 187,
+                    source_end_position: 234,
+                    comment_text: "This is a single-line comment in TypeScript.".to_string()
+                },
+                Comment {
+                    source_line_number: 11,
+                    source_start_position: 291,
+                    source_end_position: 413,
+                    comment_text:
+                        "\nThis is a multi-line comment\nthat spans across several lines.\n"
+                            .to_string()
+                },
+                Comment {
+                    source_line_number: 16,
+                    source_start_position: 499,
+                    source_end_position: 530,
+                    comment_text: "Inline multi-line comment".to_string()
+                },
+                Comment {
+                    source_line_number: 19,
+                    source_start_position: 566,
+                    source_end_position: 592,
+                    comment_text: "Method to get the value".to_string()
+                },
+                Comment {
+                    source_line_number: 21,
+                    source_start_position: 676,
+                    source_end_position: 720,
+                    comment_text: "Inline comment next to a return statement".to_string()
+                }
             ]
         );
 

--- a/src/parsers/xml.rs
+++ b/src/parsers/xml.rs
@@ -35,6 +35,7 @@ fn comments_parser() -> anyhow::Result<impl CommentsParser> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parsers::Comment;
 
     #[test]
     fn parses_xml_comments_correctly() -> anyhow::Result<()> {
@@ -58,10 +59,30 @@ mod tests {
         assert_eq!(
             blocks,
             vec![
-                (2, "This is a comment".to_string()),
-                (4, "Another comment".to_string()),
-                (6, "\nMultiline comment\n<foo>bar</foo>\n".to_string()),
-                (11, "Final comment".to_string()),
+                Comment {
+                    source_line_number: 2,
+                    source_start_position: 13,
+                    source_end_position: 39,
+                    comment_text: "This is a comment".to_string()
+                },
+                Comment {
+                    source_line_number: 4,
+                    source_start_position: 75,
+                    source_end_position: 99,
+                    comment_text: "Another comment".to_string()
+                },
+                Comment {
+                    source_line_number: 6,
+                    source_start_position: 153,
+                    source_end_position: 244,
+                    comment_text: "\nMultiline comment\n<foo>bar</foo>\n".to_string()
+                },
+                Comment {
+                    source_line_number: 11,
+                    source_start_position: 277,
+                    source_end_position: 299,
+                    comment_text: "Final comment".to_string()
+                }
             ]
         );
 

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -15,7 +15,7 @@ fn comments_parser() -> anyhow::Result<impl CommentsParser> {
         yaml_language,
         vec![(
             line_comment_query,
-            Some(|_, comment| Some(comment.strip_prefix("#").unwrap().trim().to_string())),
+            Some(|_, comment| Some(comment.strip_prefix('#').unwrap().trim().to_string())),
         )],
     );
     Ok(parser)
@@ -24,6 +24,7 @@ fn comments_parser() -> anyhow::Result<impl CommentsParser> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parsers::Comment;
 
     #[test]
     fn parses_yaml_comments_correctly() -> anyhow::Result<()> {
@@ -45,11 +46,36 @@ list:
         assert_eq!(
             blocks,
             vec![
-                (2, "This is a YAML comment".to_string()),
-                (3, "Inline comment on a key-value pair".to_string()),
-                (5, "Another comment".to_string()),
-                (7, "Comment in a list".to_string()),
-                (9, "End of comments".to_string()),
+                Comment {
+                    source_line_number: 2,
+                    source_start_position: 1,
+                    source_end_position: 25,
+                    comment_text: "This is a YAML comment".to_string()
+                },
+                Comment {
+                    source_line_number: 3,
+                    source_start_position: 38,
+                    source_end_position: 74,
+                    comment_text: "Inline comment on a key-value pair".to_string()
+                },
+                Comment {
+                    source_line_number: 5,
+                    source_start_position: 76,
+                    source_end_position: 93,
+                    comment_text: "Another comment".to_string()
+                },
+                Comment {
+                    source_line_number: 7,
+                    source_start_position: 111,
+                    source_end_position: 130,
+                    comment_text: "Comment in a list".to_string()
+                },
+                Comment {
+                    source_line_number: 9,
+                    source_start_position: 141,
+                    source_end_position: 158,
+                    comment_text: "End of comments".to_string()
+                }
             ]
         );
 


### PR DESCRIPTION
Refactor `CommentsParser` to return structured `Comment`s instead of tuples, update the language parsers tests, rework the parser tests.