### PR TITLE
Refactor: Separate sync and async validators.

### DIFF
--- a/src/validators/line_pattern.rs
+++ b/src/validators/line_pattern.rs
@@ -1,8 +1,7 @@
 use crate::blocks::Block;
 use crate::validators;
-use crate::validators::{Validator, Violation};
+use crate::validators::{ValidatorDetector, ValidatorSync, ValidatorType, Violation};
 use anyhow::anyhow;
-use async_trait::async_trait;
 use regex::Regex;
 use serde::Serialize;
 use std::collections::HashMap;
@@ -22,15 +21,14 @@ struct LinePatternViolation {
     pattern: String,
 }
 
-#[async_trait]
-impl Validator for LinePatternValidator {
-    async fn validate(
+impl ValidatorSync for LinePatternValidator {
+    fn validate(
         &self,
-        context: Arc<validators::Context>,
+        context: Arc<validators::ValidationContext>,
     ) -> anyhow::Result<HashMap<String, Vec<Violation>>> {
         let mut violations = HashMap::new();
-        for (file_path, (file_content, blocks)) in &context.modified_blocks {
-            for block in blocks {
+        for (file_path, file_blocks) in &context.modified_blocks {
+            for block in &file_blocks.blocks {
                 let Some(pattern) = block.attributes.get("line-pattern") else {
                     continue;
                 };
@@ -45,7 +43,11 @@ impl Validator for LinePatternValidator {
                         e
                     )
                 })?;
-                for (idx, line) in block.content(file_content).lines().enumerate() {
+                for (idx, line) in block
+                    .content(&file_blocks.file_contents)
+                    .lines()
+                    .enumerate()
+                {
                     if !re.is_match(line) {
                         let line_no = block.starts_at_line + idx + 1;
                         violations
@@ -58,6 +60,26 @@ impl Validator for LinePatternValidator {
             }
         }
         Ok(violations)
+    }
+}
+
+pub(crate) struct LinePatternValidatorDetector();
+
+impl LinePatternValidatorDetector {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl ValidatorDetector for LinePatternValidatorDetector {
+    fn detect(&self, block: &Block) -> anyhow::Result<Option<ValidatorType>> {
+        if block.attributes.contains_key("line-pattern") {
+            Ok(Some(ValidatorType::Sync(Box::new(
+                LinePatternValidator::new(),
+            ))))
+        } else {
+            Ok(None)
+        }
     }
 }
 
@@ -88,78 +110,77 @@ fn create_violation(
 #[cfg(test)]
 mod validate_tests {
     use super::*;
-    use crate::blocks::Block;
+    use crate::blocks::{Block, FileBlocks};
     use crate::test_utils;
-    use crate::validators::Validator;
     use serde_json::json;
 
-    #[tokio::test]
-    async fn empty_blocks_returns_no_violations() -> anyhow::Result<()> {
+    #[test]
+    fn empty_blocks_returns_no_violations() -> anyhow::Result<()> {
         let validator = LinePatternValidator::new();
-        let context = Arc::new(validators::Context::new(HashMap::new()));
-        let violations = validator.validate(context).await?;
+        let context = Arc::new(validators::ValidationContext::new(HashMap::new()));
+        let violations = validator.validate(context)?;
         assert!(violations.is_empty());
         Ok(())
     }
 
-    #[tokio::test]
-    async fn blocks_with_empty_content_returns_no_violations() -> anyhow::Result<()> {
+    #[test]
+    fn blocks_with_empty_content_returns_no_violations() -> anyhow::Result<()> {
         let validator = LinePatternValidator::new();
-        let context = Arc::new(validators::Context::new(HashMap::from([(
+        let context = Arc::new(validators::ValidationContext::new(HashMap::from([(
             "file1".to_string(),
-            (
-                "".to_string(),
-                vec![Arc::new(Block::new(
+            FileBlocks {
+                file_contents: "".to_string(),
+                blocks: vec![Arc::new(Block::new(
                     1,
                     2,
                     HashMap::from([("line-pattern".to_string(), "[A-Z]+".to_string())]),
                     0..0,
                 ))],
-            ),
+            },
         )])));
-        let violations = validator.validate(context).await?;
+        let violations = validator.validate(context)?;
         assert!(violations.is_empty());
         Ok(())
     }
 
-    #[tokio::test]
-    async fn valid_regex_all_lines_match_returns_no_violations() -> anyhow::Result<()> {
+    #[test]
+    fn valid_regex_all_lines_match_returns_no_violations() -> anyhow::Result<()> {
         let validator = LinePatternValidator::new();
         let file1_contents = "block content goes here: FOO\nBAR\nZ";
-        let context = Arc::new(validators::Context::new(HashMap::from([(
+        let context = Arc::new(validators::ValidationContext::new(HashMap::from([(
             "file1".to_string(),
-            (
-                file1_contents.to_string(),
-                vec![Arc::new(Block::new(
+            FileBlocks {
+                file_contents: file1_contents.to_string(),
+                blocks: vec![Arc::new(Block::new(
                     1,
                     5,
                     HashMap::from([("line-pattern".to_string(), "^[A-Z]+$".to_string())]),
                     test_utils::substr_range(file1_contents, "FOO\nBAR\nZ"),
                 ))],
-            ),
+            },
         )])));
-        let violations = validator.validate(context).await?;
+        let violations = validator.validate(context)?;
         assert!(violations.is_empty());
         Ok(())
     }
 
-    #[tokio::test]
-    async fn non_matching_line_reports_first_violation_only() -> anyhow::Result<()> {
+    #[test]
+    fn non_matching_line_reports_first_violation_only() -> anyhow::Result<()> {
         let validator = LinePatternValidator::new();
         let file1_contents = "block content goes here: OK\nfail\nALSOOK";
-        let context = Arc::new(validators::Context::new(HashMap::from([(
+        let context = Arc::new(validators::ValidationContext::new(HashMap::from([(
             "file1".to_string(),
-            (
-                file1_contents.to_string(),
-                vec![Arc::new(Block::new(
+            FileBlocks {
+                file_contents: file1_contents.to_string(),
+                blocks: vec![Arc::new(Block::new(
                     1,
                     6,
                     HashMap::from([("line-pattern".to_string(), "^[A-Z]+$".to_string())]),
                     test_utils::substr_range(file1_contents, "OK\nfail\nALSOOK"),
                 ))],
-            ),
+            },
         )])));
-        let violations = validator.validate(context).await?;
+        let violations = validator.validate(context)?;
         assert_eq!(violations.len(), 1);
         assert_eq!(violations.get("file1").unwrap().len(), 1);
         assert_eq!(
@@ -180,22 +201,22 @@ mod validate_tests {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn invalid_regex_returns_error() {
+    #[test]
+    fn invalid_regex_returns_error() {
         let validator = LinePatternValidator::new();
-        let context = Arc::new(validators::Context::new(HashMap::from([(
+        let context = Arc::new(validators::ValidationContext::new(HashMap::from([(
             "file1".to_string(),
-            (
-                "".to_string(),
-                vec![Arc::new(Block::new(
+            FileBlocks {
+                file_contents: "".to_string(),
+                blocks: vec![Arc::new(Block::new(
                     10,
                     15,
                     HashMap::from([("line-pattern".to_string(), "[A-Z+".to_string())]),
                     0..0,
                 ))],
-            ),
+            },
         )])));
-        let result = validator.validate(context).await;
+        let result = validator.validate(context);
         assert!(result.is_err());
     }
 }


### PR DESCRIPTION
This allows starting Tokio runtime only when necessary. 
Mean execution time for the same input drops from 149.3ms to 61.3ms:

Before:

```shell
> hyperfine --warmup 20 "git diff --patch | ./target/release/blockwatch"
Benchmark 1: git diff --patch | ./target/release/blockwatch
  Time (mean ± σ):     149.3 ms ±  12.3 ms    [User: 112.3 ms, System: 15.8 ms]
  Range (min … max):   138.9 ms … 192.2 ms    19 runs
```

After:

```shell
> hyperfine --warmup 20 "git diff --patch | ./target/release/blockwatch"
Benchmark 1: git diff --patch | ./target/release/blockwatch
  Time (mean ± σ):      61.3 ms ±   0.7 ms    [User: 58.3 ms, System: 10.4 ms]
  Range (min … max):    59.8 ms …  63.0 ms    46 runs
```