### PR TITLE
Fix list command stdin block

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,9 +444,16 @@ blockwatch list
 # List blocks in specific files
 blockwatch list "src/**/*.rs" "**/*.md"
 
-# List only blocks affected by current changes
-git diff | blockwatch list
+# List only blocks affected by current changes (reads the diff from stdin)
+git diff | blockwatch list --diff
 ```
+
+`blockwatch list` does not read stdin by default, so it never blocks waiting for
+input. This makes it safe to run non-interactively — in CI, or when invoked by
+another program such as an AI agent — and to feed its JSON output into a pipe,
+e.g. `blockwatch list "src/**/*.ts" | jq`. Pass `--diff` to opt in to reading a
+unified diff from stdin; `list` then reports which blocks the diff touched via
+the `is_content_modified` field.
 
 The output is a JSON object.
 

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -40,7 +40,10 @@ use std::ffi::OsString;
     blockwatch -e keep-sorted -e line-count
 
     # List all found blocks
-    blockwatch list 'src/**/*.rs'",
+    blockwatch list 'src/**/*.rs'
+
+    # List blocks and mark those touched by a diff (reads stdin)
+    git diff --patch | blockwatch list --diff",
 )]
 pub struct Args {
     // <block affects="README.md:cli-docs">
@@ -99,6 +102,11 @@ pub struct Args {
 pub enum SubCommand {
     /// List all blocks found in the scanned files.
     List {
+        /// Read a unified diff from stdin to populate `is_content_modified`.
+        /// Without this flag, `list` never reads stdin.
+        #[arg(long)]
+        diff: bool,
+
         #[arg(value_name = "GLOBS")]
         globs: Vec<String>,
     },
@@ -127,7 +135,10 @@ impl Args {
     pub fn globs(&self) -> anyhow::Result<GlobSet> {
         let mut builder = GlobSetBuilder::new();
         let mut globs = self.globs.clone();
-        if let Some(SubCommand::List { globs: list_globs }) = &self.command {
+        if let Some(SubCommand::List {
+            globs: list_globs, ..
+        }) = &self.command
+        {
             globs.extend(list_globs.clone());
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,57 +17,30 @@ use std::{env, fs, process};
 
 fn main() -> anyhow::Result<()> {
     let args = flags::Args::parse();
-    let languages = language_parsers::language_parsers()?;
-    let supported_extensions = languages.keys().collect();
-    args.validate(&supported_extensions)?;
-
-    let mut glob_set = args.globs()?;
-    let is_terminal =
-        std::io::stdin().is_terminal() || env::var("BLOCKWATCH_TERMINAL_MODE").is_ok();
-    // The default (validate) command always consumes a piped diff. For `list` the
-    // diff is optional enrichment (it only populates `is_content_modified`), so it
-    // reads stdin only when `--diff` is given. By default `list` never reads stdin
-    // and therefore never blocks when stdin is a non-interactive stream that never
-    // closes (CI, or when spawned by another program such as an AI agent).
-    let wants_diff_from_stdin = match &args.command {
-        Some(flags::SubCommand::List { diff, .. }) => *diff,
-        None => true,
-    };
-    let read_diff_from_stdin = wants_diff_from_stdin && !is_terminal;
-    if glob_set.is_empty() && !read_diff_from_stdin {
-        // Match all files when there is no diff input to scope the run.
-        // This allows running `blockwatch` (or `blockwatch list`) with no globs.
-        glob_set = GlobSet::new([globset::Glob::new("**")?])?
+    match &args.command {
+        Some(flags::SubCommand::List { diff, .. }) => run_list(&args, *diff),
+        None => run_validators(&args),
     }
-    let should_scan_files = !glob_set.is_empty();
-    let path_checker = blocks::PathCheckerImpl::new(glob_set, args.ignored_globs()?);
-    let root_path = repository_root_path(fs::canonicalize(env::current_dir()?)?)?;
-    let file_system = blocks::FileSystemImpl::new(root_path);
-    let modified_lines_by_file = if read_diff_from_stdin {
-        let mut diff = String::new();
-        std::io::stdin().read_to_string(&mut diff)?;
-        diff_parser::line_changes_from_diff(diff.as_str())?
-    } else {
-        HashMap::new()
-    };
+}
 
-    let blocks = blocks::parse_blocks(
-        modified_lines_by_file,
-        should_scan_files,
-        &file_system,
-        &path_checker,
-        languages,
-        args.extensions(),
-    )?;
+/// Runs the `list` subcommand: parses every block in scope and writes a JSON report to stdout.
+///
+/// A diff is read from stdin only when `--diff` is set (and stdin is not a terminal), to
+/// populate `is_content_modified`. Otherwise `list` never touches stdin, so it is safe to run
+/// non-interactively — piped to `jq`, in CI, or when spawned by another program such as an AI agent.
+fn run_list(args: &flags::Args, read_diff_flag: bool) -> anyhow::Result<()> {
+    let read_diff = read_diff_flag && !stdin_is_terminal();
+    let context = build_context(args, read_diff)?;
+    let report = context.to_serializable_report();
+    serde_json::to_writer_pretty(std::io::stdout(), &report).context("Failed to list blocks")
+}
 
-    let context = validators::ValidationContext::new(blocks);
-
-    if matches!(args.command, Some(flags::SubCommand::List { .. })) {
-        let report = context.to_serializable_report();
-        return serde_json::to_writer_pretty(std::io::stdout(), &report)
-            .context("Failed to list blocks");
-    }
-
+/// Runs the default command: validates every block in scope and reports any violations.
+///
+/// The diff to validate is read from stdin whenever stdin is not a terminal (i.e. when a
+/// `git diff` is piped in); otherwise the whole working tree is checked.
+fn run_validators(args: &flags::Args) -> anyhow::Result<()> {
+    let context = build_context(args, !stdin_is_terminal())?;
     let (sync_validators, async_validators) = validators::detect_validators(
         &context,
         validators::DETECTOR_FACTORIES,
@@ -79,6 +52,60 @@ fn main() -> anyhow::Result<()> {
         process_violations(violations)?;
     }
     Ok(())
+}
+
+/// Parses every block the run should consider into a `ValidationContext`.
+///
+/// When `read_diff` is set, a unified diff is read from stdin and used to mark which blocks
+/// changed. With neither globs nor a diff to scope the run, the whole tree is scanned.
+fn build_context(
+    args: &flags::Args,
+    read_diff: bool,
+) -> anyhow::Result<validators::ValidationContext> {
+    let languages = language_parsers::language_parsers()?;
+    let supported_extensions = languages.keys().collect();
+    args.validate(&supported_extensions)?;
+
+    let modified_lines_by_file = if read_diff {
+        read_diff_from_stdin()?
+    } else {
+        HashMap::new()
+    };
+
+    let mut glob_set = args.globs()?;
+    if glob_set.is_empty() && !read_diff {
+        // Nothing scopes the run, so match every file.
+        glob_set = GlobSet::new([globset::Glob::new("**")?])?;
+    }
+    let should_scan_files = !glob_set.is_empty();
+
+    let path_checker = blocks::PathCheckerImpl::new(glob_set, args.ignored_globs()?);
+    let root_path = repository_root_path(fs::canonicalize(env::current_dir()?)?)?;
+    let file_system = blocks::FileSystemImpl::new(root_path);
+
+    let blocks = blocks::parse_blocks(
+        modified_lines_by_file,
+        should_scan_files,
+        &file_system,
+        &path_checker,
+        languages,
+        args.extensions(),
+    )?;
+    Ok(validators::ValidationContext::new(blocks))
+}
+
+/// Whether stdin is connected to an interactive terminal.
+///
+/// `BLOCKWATCH_TERMINAL_MODE` forces this to `true` so tests can simulate a TTY.
+fn stdin_is_terminal() -> bool {
+    std::io::stdin().is_terminal() || env::var("BLOCKWATCH_TERMINAL_MODE").is_ok()
+}
+
+/// Reads a unified diff from stdin and parses it into per-file line changes.
+fn read_diff_from_stdin() -> anyhow::Result<HashMap<PathBuf, Vec<diff_parser::LineChange>>> {
+    let mut diff = String::new();
+    std::io::stdin().read_to_string(&mut diff)?;
+    diff_parser::line_changes_from_diff(&diff)
 }
 
 fn process_violations(violations: HashMap<PathBuf, Vec<Violation>>) -> anyhow::Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,16 +24,26 @@ fn main() -> anyhow::Result<()> {
     let mut glob_set = args.globs()?;
     let is_terminal =
         std::io::stdin().is_terminal() || env::var("BLOCKWATCH_TERMINAL_MODE").is_ok();
-    if glob_set.is_empty() && is_terminal {
-        // Match all files when there is no diff input in stdin and no globs in args.
-        // This allows running `blockwatch` with no args and input.
+    // The default (validate) command always consumes a piped diff. For `list` the
+    // diff is optional enrichment (it only populates `is_content_modified`), so it
+    // reads stdin only when `--diff` is given. By default `list` never reads stdin
+    // and therefore never blocks when stdin is a non-interactive stream that never
+    // closes (CI, or when spawned by another program such as an AI agent).
+    let wants_diff_from_stdin = match &args.command {
+        Some(flags::SubCommand::List { diff, .. }) => *diff,
+        None => true,
+    };
+    let read_diff_from_stdin = wants_diff_from_stdin && !is_terminal;
+    if glob_set.is_empty() && !read_diff_from_stdin {
+        // Match all files when there is no diff input to scope the run.
+        // This allows running `blockwatch` (or `blockwatch list`) with no globs.
         glob_set = GlobSet::new([globset::Glob::new("**")?])?
     }
     let should_scan_files = !glob_set.is_empty();
     let path_checker = blocks::PathCheckerImpl::new(glob_set, args.ignored_globs()?);
     let root_path = repository_root_path(fs::canonicalize(env::current_dir()?)?)?;
     let file_system = blocks::FileSystemImpl::new(root_path);
-    let modified_lines_by_file = if !is_terminal {
+    let modified_lines_by_file = if read_diff_from_stdin {
         let mut diff = String::new();
         std::io::stdin().read_to_string(&mut diff)?;
         diff_parser::line_changes_from_diff(diff.as_str())?

--- a/tests/list.rs
+++ b/tests/list.rs
@@ -1,6 +1,9 @@
 use assert_cmd::assert::OutputAssertExt;
+use assert_cmd::cargo::CommandCargoExt;
 use assert_cmd::cargo_bin_cmd;
 use serde_json::{Value, json};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
 
 #[test]
 fn list_subcommand_with_specific_file_returns_correct_json_from_that_file_only() {
@@ -106,7 +109,7 @@ index 2fcfa70..eea9cf4 100644
 "#;
 
     let mut cmd = cargo_bin_cmd!();
-    cmd.arg("list").arg("tests/testdata/list/**");
+    cmd.arg("list").arg("--diff").arg("tests/testdata/list/**");
     let output = cmd
         .write_stdin(diff_content)
         .output()
@@ -129,4 +132,76 @@ index 2fcfa70..eea9cf4 100644
             .as_bool()
             .unwrap()
     );
+}
+
+#[test]
+fn list_subcommand_ignores_piped_diff_without_diff_flag() {
+    let diff_content = r#"
+diff --git a/tests/testdata/list/a.py b/tests/testdata/list/a.py
+index 2fcfa70..eea9cf4 100644
+--- a/tests/testdata/list/a.py
++++ b/tests/testdata/list/a.py
+@@ -1,3 +1,3 @@
+ # <block name="a" attr="val">
+-pass old
++pass
+ # </block>
+"#;
+
+    let mut cmd = cargo_bin_cmd!();
+    cmd.arg("list").arg("tests/testdata/list/**");
+    let output = cmd
+        .write_stdin(diff_content)
+        .output()
+        .expect("Failed to get command output");
+
+    output.clone().assert().success();
+
+    let actual: Value =
+        serde_json::from_slice(&output.stdout).expect("Failed to parse JSON output");
+    let report = actual.as_object().expect("Output should be a JSON object");
+
+    // Without `--diff`, the piped diff is ignored entirely, so no block is
+    // reported as modified.
+    assert_eq!(report.len(), 2);
+    assert!(
+        !report["tests/testdata/list/a.py"][0]["is_content_modified"]
+            .as_bool()
+            .unwrap()
+    );
+    assert!(
+        !report["tests/testdata/list/b.py"][0]["is_content_modified"]
+            .as_bool()
+            .unwrap()
+    );
+}
+
+#[test]
+fn list_subcommand_finishes_without_waiting_for_stdin() {
+    // `blockwatch list` (without `--diff`) takes its file set from the glob
+    // arguments, so it must complete without consuming stdin. We give it a stdin
+    // pipe that never receives any data and is never closed; if `list` tried to
+    // read it, the process would never exit and the deadline below would trip.
+    let mut child = Command::cargo_bin("blockwatch")
+        .expect("blockwatch binary should be built")
+        .args(["list", "tests/testdata/list/**"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn blockwatch");
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let status = loop {
+        if let Some(status) = child.try_wait().expect("failed to poll blockwatch") {
+            break status;
+        }
+        if Instant::now() >= deadline {
+            child.kill().ok();
+            panic!("blockwatch list is still running; it appears to be waiting on stdin");
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    };
+
+    assert!(status.success());
 }


### PR DESCRIPTION
Fixes #83 when `blockwatch list` is executed as a subprocess (e.g. from Claude Code).